### PR TITLE
Fixed application of ignored style in tree view.

### DIFF
--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -173,7 +173,7 @@
     ) center;
 }
 
-.tree-view .ignored {
+.tree-view .entry.status-ignored .name {
   color:#999;
 }
 


### PR DESCRIPTION
Prior to this change, files matching a pattern in `.gitignore` are not distinguished in tree view. This PR fixes that the same way that rschiang/unity-dark-ui@4edc0c89829a4369a028131f0dde0bc226c4b001 does.
