### PR TITLE
Smaller settings and search result tab icons.

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -51,9 +51,9 @@
   }
 
   .title.icon::before {
-    font-size: 14px;
-    height: 14px;
-    width: 14px;
+    font-size: 12px;
+    height: 12px;
+    width: 12px;
   }
 }
 


### PR DESCRIPTION
Shrink the tab icons slightly so they fit nicely within the smaller unity tabs.

Before:
![unity-before](https://cloud.githubusercontent.com/assets/122102/3678645/6e0b8bac-129c-11e4-91e8-bc3ff2d79eb3.png)

After:
![unity-after](https://cloud.githubusercontent.com/assets/122102/3678644/6e077cd8-129c-11e4-85c5-898d894e2a20.png)
