### PR TITLE
Match overlay border with native OS X popups

### DIFF
--- a/stylesheets/overlay.less
+++ b/stylesheets/overlay.less
@@ -7,6 +7,6 @@
 
   &.select-list.from-top {
     top:58px;
-    border-radius:5px;
+    border-radius:4px;
   }
 }

--- a/stylesheets/tooltip.less
+++ b/stylesheets/tooltip.less
@@ -2,7 +2,7 @@
 
 .tooltip-inner {
   background:#f8f8f8;
-  border-radius:5px;
+  border-radius:4px;
   font-size:12px;
   color:#333;
   text-shadow:#fff 0 1px 0;


### PR DESCRIPTION
This branch uses the border color and radius from OS X popup controls in the unity overlay.

Before:
![overlay-before](https://cloud.githubusercontent.com/assets/122102/3679000/0b7a70f8-12a0-11e4-978e-97e9a19b4575.png)

After:
![overlay-after](https://cloud.githubusercontent.com/assets/122102/3678999/0b64f8b8-12a0-11e4-940a-dee32f2b7981.png)
