### PR TITLE
Fix tooltip arrow

### DIFF
--- a/stylesheets/tooltip.less
+++ b/stylesheets/tooltip.less
@@ -9,6 +9,7 @@
   padding:10px 12px;
   box-shadow:rgba(0,0,0,0.15) 0 0 0 1px, rgba(0,0,0,0.25) 0 1px 3px;
   word-wrap:break-word;
+  max-width: none;
 }
 
 .tooltip {


### PR DESCRIPTION
Give the arrow a border and let file paths live on a single line.

Before:
![tooltip-before](https://cloud.githubusercontent.com/assets/122102/3680513/5c5b4a6a-12af-11e4-9948-9ba8539ab6e7.png)

After:
![tooltip-after](https://cloud.githubusercontent.com/assets/122102/3680514/5c7b0c92-12af-11e4-9f3a-e245ff1a905b.png)
