### PR TITLE
Fix tooltip arrow border clipping.

### DIFF
--- a/stylesheets/tooltip.less
+++ b/stylesheets/tooltip.less
@@ -22,8 +22,8 @@
       content: '';
       border: 1px solid rgba(0,0,0,0.20);
       background-color: @tooltip-arrow-color;
-      width: 10px;
-      height: 10px;
+      width: 11px;
+      height: 11px;
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
I missed the border clip by 1px in https://github.com/orderedlist/unity-ui/pull/21 so it bleeds into the tooltip area. It's easier to spot it now that I'm looking at my retina display.

Before:
![before](https://cloud.githubusercontent.com/assets/122102/3692218/89739808-135a-11e4-9631-392b2ead37ea.png)

After:
![after](https://cloud.githubusercontent.com/assets/122102/3692217/8969fe88-135a-11e4-8160-9bf8b2e4c482.png)
