### PR TITLE
Fix for broken overlays with Autocomplete Plus

### DIFF
--- a/index.less
+++ b/index.less
@@ -14,3 +14,4 @@
 @import "stylesheets/tooltip";
 @import "stylesheets/background-tips";
 @import "stylesheets/release-notes";
+@import "stylesheets/plugin-styles";

--- a/stylesheets/plugin-styles.less
+++ b/stylesheets/plugin-styles.less
@@ -1,0 +1,14 @@
+// Fix for autocomplete plus
+.overlay {
+  &.autocomplete-plus {
+    &.select-list ol.list-group,
+    &.select-list .error-message {
+      border-radius: 5px !important;
+      margin: 0 !important;
+    }
+
+    &.select-list.popover-list ol {
+      width: 100% !important;
+    }
+  }
+}

--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -246,8 +246,8 @@
 
   .tab-bar .tab.modified:not(:hover) .close-icon {
     display:block;
-    top:0;
-    border:none;
+    top: 8px;
+    left: 8px;
   }
 
   .tab-bar .tab:hover .close-icon {


### PR DESCRIPTION
This is a small fix for using [Autocomplete Plus](https://atom.io/packages/autocomplete-plus) and Unity-UI together. It overrides the default styling of Autocomplete Plus overlay so it better matches the Unity UI theme.
