### PR TITLE
Yosemite tab close tweaks

### DIFF
--- a/stylesheets/tabs.less
+++ b/stylesheets/tabs.less
@@ -225,21 +225,26 @@
   .tab-bar .tab .close-icon {
     color:rgb(93, 93, 93) !important;
     cursor:default;
-    top:0;
-    left:0;
-    height:24px;
-    width:20px;
+    top:4px;
+    left:4px;
+    height:16px;
+    width:16px;
     right:auto;
     position:absolute;
     display:none;
+    border-radius:2px;
 
     &:before {
       content:'✕';
       position:absolute;
-      top:6px;
-      left:5px;
+      top:2px;
+      left:2px;
       width:12px;
       height:13px;
+    }
+
+    &:hover {
+      background:rgb(194, 194, 194);
     }
   }
 


### PR DESCRIPTION
Draw a round-rect background for tab close buttons to match Safari on OS X Yosemite. I tried getting the close icon to transition in and out on hover too, but it conflicts with the blue modified status indicator.

Hover over tab displays close icon:
![close](https://cloud.githubusercontent.com/assets/122102/5323073/45266bae-7c81-11e4-9db0-7a67bb2a9663.png)

Hover over close icon displays background:
![close-hover](https://cloud.githubusercontent.com/assets/122102/5323074/453df904-7c81-11e4-8ba7-86c1c7c47e92.png)
