### PR TITLE
Fix error if no element found

### DIFF
--- a/lib/unity-ui.coffee
+++ b/lib/unity-ui.coffee
@@ -1,7 +1,9 @@
 addClass = (el, klass) ->
+  return unless el
   el.className = "#{el.className} #{klass}"
 
 removeClass = (el, klass) ->
+  return unless el
   classes = el.className.split(' ')
   index = classes.indexOf(klass)
   classes.splice(index, 1) if index >= 0


### PR DESCRIPTION
In removing jQuery, the new script wasn't gracefully handling when elements didn't exist. Fixes #50.