### PR TITLE
Remove deprecated selectors, as suggested by Deprecation Cop...

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -40,12 +40,12 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   }
 }
 
-.editor .highlighted.selection .region {
+.atom-text-editor .highlighted.selection .region {
   -webkit-animation-name: highlight;
   -webkit-animation-duration: 1s;
   -webkit-animation-iteration-count: 1;
 }
 
-.editor .invisible-character {
+.atom-text-editor .invisible-character {
   opacity:0.25;
 }

--- a/stylesheets/select-list.less
+++ b/stylesheets/select-list.less
@@ -18,7 +18,7 @@
   border-radius:5px;
   padding:12px;
 
-  .editor {
+  .atom-text-editor {
     margin-bottom:12px;
   }
 

--- a/stylesheets/tree-view.less
+++ b/stylesheets/tree-view.less
@@ -221,7 +221,7 @@ atom-panel.right .tree-view-resizer {
   font-weight:normal;
   padding-bottom:6px;
 
-  .editor {
+  .atom-text-editor {
     margin:4px 0 0;
   }
 }


### PR DESCRIPTION
This removes the following warning:
Use the `atom-text-editor` tag instead of the `editor` class.