### PR TITLE
Use native checkboxes

### DIFF
--- a/index.less
+++ b/index.less
@@ -15,3 +15,4 @@
 @import "stylesheets/background-tips";
 @import "stylesheets/release-notes";
 @import "stylesheets/plugin-styles";
+@import "stylesheets/settings";

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -1,0 +1,17 @@
+.settings-view {
+
+  .checkbox {
+    padding-left: 20px;
+
+    input[type="checkbox"] {
+      all: unset;
+      -webkit-appearance: checkbox;
+      float: left;
+      margin: 2px 0 0 -20px;
+      &:before {
+        content: none;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR "unsets" the custom styling of checkboxes in the settings.

Before:
![screen shot 2015-01-29 at 10 51 25 am](https://cloud.githubusercontent.com/assets/378023/5951026/d23a8806-a7a4-11e4-97c0-619d68d54cd3.png)

After:
![screen shot 2015-01-29 at 10 51 00 am](https://cloud.githubusercontent.com/assets/378023/5951032/da24aff6-a7a4-11e4-992d-b7f765b92ec6.png)

I also tried to make the `<select>`s look native, but unlike the checkboxes, this 

```css
.settings-view select.form-control {
  all: unset;
  -webkit-appearance: menulist;
}
```

doesn't seem to work. The only thing I can think of is removing the `form-control` class on load and then position it again. But that might cause other issues.