### PR TITLE
Restore selected search result blue background styles.

### DIFF
--- a/styles/text.less
+++ b/styles/text.less
@@ -89,6 +89,20 @@ code {
   color: darken(@text-color-highlight, 18%);
 }
 
+.results-view .selected {
+  &::before {
+    content: '\00a0';
+  }
+
+  .highlight-info {
+    color: inherit;
+  }
+
+  .preview {
+    color: #fff;
+  }
+}
+
 .background-message {
   font-weight:200;
 


### PR DESCRIPTION
The blue background on the selected search result was lost in a recent Atom update. This branch restores it by adding a space character to the result's `::before` pseudo element.

![screen shot 2015-05-20 at 5 38 59 pm](https://cloud.githubusercontent.com/assets/122102/7738934/6f58f068-ff17-11e4-8846-9d98d24341a0.png)