### PR TITLE
Set warning color to brown

### DIFF
--- a/styles/git.less
+++ b/styles/git.less
@@ -1,6 +1,6 @@
 .status { .text(normal); }
 .status-added    { .text(success); } // green
 .status-ignored  { .text(subtle); }  // faded
-.status-modified { .text(warning); } // orange
+.status-modified { .text(warning); } // yellow
 .status-removed  { .text(error); }   // red
 .status-renamed  { .text(info); }    // blue

--- a/styles/git.less
+++ b/styles/git.less
@@ -1,6 +1,6 @@
 .status { .text(normal); }
 .status-added    { .text(success); } // green
 .status-ignored  { .text(subtle); }  // faded
-.status-modified { .text(warning); } // yellow
+.status-modified { .text(warning); } // brown
 .status-removed  { .text(error); }   // red
 .status-renamed  { .text(info); }    // blue

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -5,7 +5,7 @@
 @text-color-selected: #fff;
 @text-color-info:#4BB8F3;
 @text-color-success:#6DCC50;
-@text-color-warning:#FFFF00;
+@text-color-warning:#9F8A00;
 @text-color-error:#FF625C;
 
 // Background colors

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -5,7 +5,7 @@
 @text-color-selected: #fff;
 @text-color-info:#4BB8F3;
 @text-color-success:#6DCC50;
-@text-color-warning:#F9A646;
+@text-color-warning:#FFFF00;
 @text-color-error:#FF625C;
 
 // Background colors


### PR DESCRIPTION
The previous orange color was almost unreadable against the default gray
background, this is better.