### PR TITLE
Shrink search loading spinner.

### DIFF
--- a/styles/spinner.less
+++ b/styles/spinner.less
@@ -25,5 +25,5 @@
 }
 
 .loading-spinner-tiny {
-  .loading-spinner(20px);
+  .loading-spinner(12px);
 }


### PR DESCRIPTION
The larger spinner causes a slight line height jump between the searching and result states. The new size keeps the header a consistent height during both search phases. I'm not sure it's the best spinner size, or if a spinner is really needed at all, but it does prevent the header from jumping.

![search](https://cloud.githubusercontent.com/assets/122102/7900416/71d7ed5e-0713-11e5-8f76-0a03b843efd3.png)
