### PR TITLE
El Capitan

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -1,4 +1,5 @@
 .btn {
+  cursor: default;
   font-size:@font-size;
   height:24px;
   box-shadow:0 0 3px 7px fade(#92bcea, 0), 0 1px 0 rgba(0,0,0,0.1);
@@ -78,7 +79,7 @@
     &:hover {
       color:@text-color-selected;
     }
-    
+
     &:active, &.selected {
       background:darken(@background-color-error, 10%);
       color:@text-color-selected;

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -2,8 +2,10 @@
   cursor: default;
   font-size:@font-size;
   height:24px;
-  box-shadow:0 0 3px 7px fade(#92bcea, 0), 0 1px 0 rgba(0,0,0,0.1);
-  transition:box-shadow 0.1s ease-in-out;
+  border-top: 1px solid #c8c8c8;
+  border-left: 1px solid #c2c2c2;
+  border-right: 1px solid #c2c2c2;
+  border-bottom: 1px solid #acacac;
 
   &:active {
     background:#f4f4f4;
@@ -94,19 +96,24 @@
 
 .btn-group {
   .btn {
-    box-shadow:rgba(0,0,0,0.1) 0 1px 0;
     margin:0;
-    border:none;
+    border-top: 1px solid #c8c8c8;
+    border-left: 1px solid #c2c2c2;
+    border-right: 1px solid #c2c2c2;
+    border-bottom: 1px solid #acacac;
 
-    & + .btn {
-      box-shadow:inset rgba(0,0,0,0.05) 1px 0 0, rgba(0,0,0,0.1) 0 1px 0;
-      margin-left:0;
+    &:first-child {
+      border-left: 1px solid #c2c2c2;
+    }
+
+    &:last-child {
+      border-right: 1px solid #c2c2c2;
     }
 
     &.selected {
       background:#6a6a6a;
       color:#fff;
-      box-shadow:inset rgba(0,0,0,0.15) 1px 0 0, inset rgba(0,0,0,0.15) -1px 0 0, rgba(0,0,0,0.1) 0 1px 0;
+      box-shadow:inset rgba(0,0,0,0.15) 1px 0 0, inset rgba(0,0,0,0.15) -1px 0 0;
 
       & + .btn {
         box-shadow:rgba(0,0,0,0.1) 0 1px 0;

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -7,8 +7,8 @@ atom-text-editor[mini] {
   border:none;
   font-family:@font-family;
   background-color: @input-background-color;
-  padding-left: @component-padding/2;
   box-shadow:0 0 3px 7px fade(#92bcea, 0), 0 1px 0 rgba(0,0,0,0.1);
+  padding-left: 3px;
   transition:box-shadow 0.1s ease-in-out;
   height:24px;
 

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -2,13 +2,13 @@ atom-text-editor[mini] {
   padding-left: 0;
   font-size:@font-size;
   padding:4px 0;
-  border-radius: @component-border-radius;
+  border-radius: 0;
   color: @text-color-highlight;
-  border:none;
+  border: 1px solid #dedede;
   font-family:@font-family;
   background-color: @input-background-color;
-  box-shadow:0 0 3px 7px fade(#92bcea, 0), 0 1px 0 rgba(0,0,0,0.1);
   padding-left: 3px;
+  box-shadow:0 0 3px 7px fade(#92bcea, 0);
   transition:box-shadow 0.1s ease-in-out;
   height:24px;
 
@@ -32,7 +32,8 @@ atom-text-editor[mini] {
     opacity:1;
     outline:none;
     box-shadow:0 0 0px 3px #92bcea;
-    border:none;
+    border: 1px solid transparent;
+    border-radius: @component-border-radius;
 
     .selection .region {
       background-color: #B2D7FF;

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -67,7 +67,9 @@ atom-panel {
 }
 
 .find-and-replace .find-meta-container {
-  margin-top:3px;
+  margin-top:4px;
   font-size:1em;
   color:@text-color-subtle;
+  line-height: 1.5;
+  top: inherit;
 }

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -68,6 +68,7 @@ atom-panel {
 
 .find-and-replace .find-meta-container {
   margin-top:4px;
+  margin-right: 2px;
   font-size:1em;
   color:@text-color-subtle;
   line-height: 1.5;

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -47,6 +47,7 @@
         border-bottom:1px solid fade(@pane-item-border-color, 20%);
 
         a {
+          cursor: default;
           padding:0 @component-padding;
           line-height:@component-padding*3;
         }

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -1,5 +1,10 @@
 .settings-view {
 
+  .setting-title {
+    font-size: 1em;
+    color: #222;
+  }
+
   .icon:before {
     opacity:0.3;
   }

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -75,7 +75,6 @@
     }
 
     .editor-container {
-      margin:@component-padding 0 0;
       padding:0 0 @component-padding;
     }
 

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -10,20 +10,23 @@
   }
 
   .checkbox {
-    padding-left: 20px;
+    padding-left: 0;
 
     input[type="checkbox"] {
       all: unset;
       -webkit-appearance: checkbox;
-      float: left;
-      margin: 2px 0 0 -20px;
       cursor: default;
+      margin: 0 4px 0 0;
       &:before {
         content: none;
       }
       &:after {
         content: none;
       }
+    }
+
+    .setting-description {
+      padding-left: 16px;
     }
 
     label {

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -62,6 +62,14 @@
     border-top:1px solid fade(@pane-item-border-color, 20%);
   }
 
+  .section-heading-count {
+    margin-left: 1em;
+    margin-top: -1px;
+    color: #999;
+    padding: 0;
+    background-color: inherit;
+  }
+
   .section, .section:first-child, .section:last-child {
     padding:@component-padding;
     border-color:fade(@pane-item-border-color, 20%);

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -78,6 +78,10 @@
       padding:0 0 @component-padding;
     }
 
+    .sub-section .sub-section-heading:after {
+      line-height: 36px;
+    }
+
     .section-heading, .sub-section h3 {
       border-bottom:1px solid fade(@pane-item-border-color, 20%);
       background:@tool-panel-background-color;

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -17,12 +17,17 @@
       -webkit-appearance: checkbox;
       float: left;
       margin: 2px 0 0 -20px;
+      cursor: default;
       &:before {
         content: none;
       }
       &:after {
         content: none;
       }
+    }
+
+    label {
+      cursor: default;
     }
   }
 

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -70,6 +70,14 @@
     background-color: inherit;
   }
 
+  .sub-section .sub-section-heading {
+    cursor: default;
+
+    &:after {
+      line-height: 36px;
+    }
+  }
+
   .section, .section:first-child, .section:last-child {
     padding:@component-padding;
     border-color:fade(@pane-item-border-color, 20%);
@@ -84,10 +92,6 @@
 
     .editor-container {
       padding:0 0 @component-padding;
-    }
-
-    .sub-section .sub-section-heading:after {
-      line-height: 36px;
     }
 
     .section-heading, .sub-section h3 {

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -2,7 +2,7 @@
   border-top:1px solid @pane-item-border-color;
   border-bottom:1px solid #b7b5b7;
   font-size:@font-size - 1;
-  height:27px;
+  height:24px;
   background: linear-gradient(@tab-background-color,#C7C6C7);
   display:table;
   table-layout: fixed;
@@ -14,13 +14,13 @@
     width:100%;
     box-sizing:border-box;
     padding:0 20px!important;
-    line-height:24px;
+    line-height:22px;
     color:#696869;
     text-align:center;
     position:relative;
-    border-left:1px solid #b7b5b7;
+    border-left:1px solid #a4a2a4;
     display:table-cell;
-    background:@tab-background-color;
+    background: linear-gradient(#c2c0c2, #bbb9bb);
 
     &:first-child {
       border-left:none;
@@ -37,17 +37,17 @@
     }
 
     &:hover {
-      background:#bcbcbc;
+      background: linear-gradient(#b9b7b9, #b2b0b2);
     }
   }
 
   .tab.active,
   .tab:hover.active {
     color:#202020;
-    background:@tab-background-color-active;
+    background: linear-gradient(#dedcde, #d7d5d7);
     border-width:1px 0 1px 1px;
     border-top-color:#B5B4B5;
-    border-left-color:#B7B6B7;
+    border-left-color:#a2a1a2;
     border-bottom-color:#A8A7A8;
     width:100%;
 
@@ -67,7 +67,7 @@
   .tab .close-icon {
     color:rgb(93, 93, 93) !important;
     cursor:default;
-    top:4px;
+    top:3px;
     left:4px;
     height:16px;
     width:16px;
@@ -80,16 +80,20 @@
 
     &:before {
       content:'✕';
-      position:absolute;
-      top:2px;
-      left:2px;
-      width:12px;
-      height:13px;
+      width:16px;
+      height:16px;
+      line-height: 17px;
+      font-size: 11px;
+      display: block;
     }
 
     &:hover {
-      background:rgba(0,0,0,0.1);
+      background: linear-gradient(#a3a1a3, #9f9d9f);
     }
+  }
+
+  .tab.active .close-icon:hover {
+    background: linear-gradient(#c5c3c5, #c1bfc1);
   }
 
   &:hover .tab {
@@ -102,10 +106,9 @@
 
   .tab.modified:not(:hover) .close-icon {
     opacity:1;
-    top: 8px;
+    top: 7px;
     left: 8px;
     display:inline-block;
-
   }
 
   .tab:hover .close-icon {

--- a/styles/tooltip.less
+++ b/styles/tooltip.less
@@ -2,11 +2,11 @@
 
 .tooltip-inner {
   background:#f8f8f8;
-  border-radius:4px;
+  border-radius:2px;
   font-size:12px;
   color:@text-color-highlight;
   text-shadow:#fff 0 1px 0;
-  padding:10px 12px;
+  padding:4px 8px;
   box-shadow:rgba(0,0,0,0.15) 0 0 0 1px, rgba(0,0,0,0.25) 0 1px 3px;
   word-wrap:break-word;
   max-width: none;

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -14,7 +14,7 @@
 @background-color-warning:@text-color-warning;
 @background-color-error:@text-color-error;
 @background-color-highlight:#D0E6E7;
-@background-color-selected:#0364E3;
+@background-color-selected:#006ed7;
 @app-background-color: #e4e4e4;
 
 // Base colors


### PR DESCRIPTION
Updated styles for OS X El Capitan. The commit history is a good log of the changes.

The major missing item is the San Francisco system font. It isn't listed in Font Book and seems to only be accessible as `-apple-system` in Safari. Hopefully it will appear in the final release.

Input and button styles in find/replace panel:
![screen shot 2015-08-10 at 8 04 18 pm](https://cloud.githubusercontent.com/assets/122102/9188635/8a52dd9c-3f9b-11e5-99c0-108d0bbf2378.png)

Settings panel:
![screen shot 2015-08-10 at 8 04 00 pm](https://cloud.githubusercontent.com/assets/122102/9188642/95d33f9a-3f9b-11e5-9e40-c0ef7f0094ce.png)

The Cap'n:
![iu](https://cloud.githubusercontent.com/assets/122102/9188679/0545c8a2-3f9c-11e5-827d-1aea19755544.jpeg)


