### PR TITLE
Match thicknes of window top border.

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,5 +1,5 @@
 .tab-bar {
-  border-top:1px solid @pane-item-border-color;
+  border-top:0;
   border-bottom:1px solid #b7b5b7;
   font-size:@font-size - 1;
   height:24px;

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -117,7 +117,7 @@
 }
 
 .tree-view-resizer {
-  border-top:1px solid @tree-view-border-color;
+  border-top:0;
 
   .tree-view-resize-handle {
     width: 8px;


### PR DESCRIPTION
1 px top border is more consistent with other Yosemite apps (Safari etc.).