### PR TITLE
Use San Francisco font

### DIFF
--- a/styles/overlay.less
+++ b/styles/overlay.less
@@ -45,7 +45,7 @@ atom-panel.modal {
     li {
       padding: @component-padding;
       border-bottom: 1px solid fade(@overlay-border-color, 5%);
-      font-weight:500;
+      font-weight:600;
 
       &:last-of-type {
         border-bottom: none;

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -42,7 +42,7 @@ atom-panel {
   border-top: 1px solid fade(@panel-heading-border-color, 50%);
   border-bottom: 1px solid @panel-heading-border-color;
   background-color: @panel-heading-background-color;
-  font-weight:500;
+  font-weight:600;
 
   &:first-of-type {
     border-top:none;

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -44,7 +44,7 @@
     }
 
     .panels-menu {
-      font-weight:500;
+      font-weight:600;
 
       li {
         border-bottom:1px solid fade(@pane-item-border-color, 20%);
@@ -98,7 +98,7 @@
       border-bottom:1px solid fade(@pane-item-border-color, 20%);
       background:@tool-panel-background-color;
       font-size:13px;
-      font-weight:500;
+      font-weight:600;
       margin:-@component-padding -@component-padding @component-padding;
       padding:0 @component-padding;
       line-height:@component-padding*3;
@@ -159,7 +159,7 @@
     margin-bottom:@component-padding;
 
     .card-name {
-      font-weight:500;
+      font-weight:600;
     }
 
     .package-description {
@@ -191,7 +191,7 @@
     border-bottom:1px solid fade(@pane-item-border-color, 20%);
     background:@tool-panel-background-color;
     font-size:13px;
-    font-weight:500;
+    font-weight:600;
     margin:0;
     padding:0 @component-padding;
     line-height:@component-padding*3;

--- a/styles/text.less
+++ b/styles/text.less
@@ -105,6 +105,7 @@ code {
 
 .background-message {
   font-weight:200;
+  font-family: ".SFNSDisplay-Light", "Helvetica Neue";
 
   .message {
     padding:0 10%;

--- a/styles/tooltip.less
+++ b/styles/tooltip.less
@@ -4,6 +4,7 @@
   background:#f8f8f8;
   border-radius:2px;
   font-size:12px;
+  font-family: @font-family;
   color:@text-color-highlight;
   text-shadow:#fff 0 1px 0;
   padding:4px 8px;
@@ -53,11 +54,5 @@
     -webkit-transform: rotate(315deg);
     transform: rotate(315deg);
     border: 0;
-  }
-}
-
-.unity-mac-new {
-  .tooltip-inner {
-    font:12px "Helvetica Neue";
   }
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -64,4 +64,4 @@
 
 // Misc
 @component-border-radius:4px;
-@font-family:"Helvetica Neue", Helvetica;
+@font-family: ".SFNSDisplay-Regular", "Helvetica Neue", Helvetica;


### PR DESCRIPTION
San Francisco is available in Safari as -apple-system but is not usable by name, like other fonts. Chrome does not support -apple-system, so we’ll use the secret, hidden name of the font for now.

This name is subject to change at any time. Hopefully we can use `font-face: system` in the future.