### PR TITLE
Fix status bar and overlays

### DIFF
--- a/styles/overlay.less
+++ b/styles/overlay.less
@@ -2,6 +2,7 @@ atom-panel.modal {
   color: @text-color;
   background-color: transparent;
   padding: @component-padding @component-padding 0;
+  border-top:none !important;
 
   .loading {
     position:absolute;
@@ -96,7 +97,6 @@ atom-panel.modal {
     }
   }
 
-
   & > * {
     position: relative; // fixes stacking order
   }
@@ -111,7 +111,6 @@ atom-panel.modal {
     bottom: 0;
     z-index: 0;
     background-color: @overlay-background-color;
-    border-top: 1px solid @pane-item-border-color;
     box-shadow: 0  5px 20px fade(#000, 20%), fade(#000, 10%) 0 0 0 1px;
   }
 

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -52,10 +52,13 @@ atom-panel {
 .status-bar {
   color: fadeout(@text-color-highlight, 30%);
   height:26px;
-  line-height:23px;
-  padding:0;
+  line-height:16px;
   background:linear-gradient(#e4e4e4, #d8d8d8);
   border-color:#a1a1a1;
+
+  .flexbox-repaint-hack {
+    padding:3px 0;
+  }
 
   .status-bar-left {
     margin-left:@component-padding;


### PR DESCRIPTION
Vertically centers status bar with new San Francisco font additions, and removes top border from overlays now that Atom has a border at the bottom of the window bar.