### PR TITLE
Opt-out of using custom controls

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -65,3 +65,4 @@
 // Misc
 @component-border-radius:4px;
 @font-family: -apple-system, "Helvetica Neue", Helvetica;
+@use-custom-controls: false; // use native controls


### PR DESCRIPTION
Atom `1.10` will introduce a couple input controls that adapt to the theme colors, see https://github.com/atom/atom-ui/pull/8.

This PR opts-out of using custom styling and keeps the controls native.

Before | After
--- | ---
![screen shot 2016-07-13 at 12 38 36 pm](https://cloud.githubusercontent.com/assets/378023/16791132/d759c4ba-48f6-11e6-9ba3-7f05a30b49b7.png) | ![screen shot 2016-07-13 at 12 39 07 pm](https://cloud.githubusercontent.com/assets/378023/16791138/dd0e56a0-48f6-11e6-9f6a-74b6f6f85bac.png)
