### PR TITLE
Fix rounded tab bar

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -1,6 +1,7 @@
 .tab-bar {
   border-top:0;
   border-bottom:1px solid #b7b5b7;
+  border-radius: 0;
   font-size:@font-size - 1;
   height:24px;
   background: linear-gradient(@tab-background-color,#C7C6C7);


### PR DESCRIPTION
At some point the tab bar started showing a little bit of round when it was empty. This, well, makes it not.