### PR TITLE
Fix selection color

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -12,6 +12,7 @@ atom-text-editor[mini] {
   height:24px;
 
   &,
+  &::shadow,
   &.editor {
     .placeholder-text {
       color: @text-color-subtle;
@@ -26,6 +27,7 @@ atom-text-editor[mini] {
   }
 
   &.is-focused,
+  &.is-focused::shadow,
   &.is-focused.editor {
     background-color: #fff;
     opacity:1;


### PR DESCRIPTION
Add ::shadow back in until it's totally removed. Keeps new .editor syntax as well, so we should be good for a while.

Fixes #90.