### PR TITLE
Remove height restriction from input

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -9,7 +9,7 @@ atom-text-editor[mini] {
   background-color: @input-background-color;
   box-shadow:0 0 3px 7px fade(#92bcea, 0);
   transition:box-shadow 0.2s ease-in-out;
-  height:24px;
+  min-height:24px;
 
   &,
   &::shadow,


### PR DESCRIPTION
By default input fields in find dialog are single-lined, but when you paste multi-lined text they could expand so you could adjust a text you’re searching or replacing. I always though that it’s Atom’s fault that those fields are not expanded, but today I realized that it caused by `height: 24px` line in Atom Light/Dark, Unity UI and probably some other themes. In One Dark/Lite theme it works much better.

So here’s how it looks now with multiline text pasted:

<img width="684" alt="screen shot 2017-01-23 at 01 01 36" src="https://cloud.githubusercontent.com/assets/105274/22186526/606cff84-e108-11e6-891d-acea302bd7ac.png">

And how it will work with my PR merged and released:

<img width="682" alt="screen shot 2017-01-23 at 01 01 47" src="https://cloud.githubusercontent.com/assets/105274/22186535/75f2d306-e108-11e6-9673-f50ab861a34b.png">

I think it makes search much more powerful. I hope you’ll agree.