### PR TITLE
Fix line-height in close tab icon

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -85,7 +85,7 @@
       content:'✕';
       width:16px;
       height:16px;
-      line-height: 17px;
+      line-height: 15px;
       font-size: 11px;
       display: block;
     }


### PR DESCRIPTION
In the close tab button, X was not aligned to the center.
![before](https://user-images.githubusercontent.com/30773107/45635247-29e85280-baad-11e8-9a12-f00a7684397a.png)

I pushed it upwards.
![after](https://user-images.githubusercontent.com/30773107/45635281-3ff61300-baad-11e8-95c8-440559bdbae5.png)
